### PR TITLE
Conversation matching fails on multi line replies

### DIFF
--- a/src/parseContents.js
+++ b/src/parseContents.js
@@ -187,7 +187,7 @@ const processConversations = function processConversations(data) {
         gambit.conversation = triggerParser.parse(gambit.conversation.raw);
         // Add punctuation at the end so can still match replies that have punctuation
         const pattern = new RegExp(`^${gambit.conversation.clean}\\s*[?!.]*$`, 'i');
-        if (pattern.test(reply.string)) {
+        if (pattern.test(reply.string.replace(/\\n/g, ' '))) {
           repliesMatched.push(id);
         }
       });


### PR DESCRIPTION
See issue @superscript Conversation matching fails on multi line replies #357

# Description
This fixes the pattern matching for conversations based on multi line replies. I.e. if the reply contains a line break (\n) the pattern matching fails if the word after (or before) the line break is used for conversation matching. The fix replaces the line breaks in the reply with a single white space for the pattern matching only. The reply will not be altered.

## Motivation and Context
This ensures conversation matching works as expected even if line breaks are used in the replies.

## How Has This Been Tested?
See issue @superscript Conversation matching fails on multi line replies #357
A simple failing test has been added to the continue test script. This test is passed successfully and no other tests fail due to the change in the ss-parser.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
